### PR TITLE
fix(auth-pages): remove unnecessary font-size and font-weight

### DIFF
--- a/src/components/layouts/AuthLayout/AuthLayout.styles.ts
+++ b/src/components/layouts/AuthLayout/AuthLayout.styles.ts
@@ -112,8 +112,6 @@ export const FormItem = styled(CommonFormItem)`
 `;
 
 export const FormInput = styled(CommonInput)`
-  font-size: ${(props) => props.theme.commonFontSizes.xs};
-  font-weight: ${(props) => props.theme.commonFontWeight.semibold};
   color: ${(props) => props.theme.colors.text.main};
   background: transparent;
 
@@ -123,9 +121,7 @@ export const FormInput = styled(CommonInput)`
 `;
 
 export const FormInputPassword = styled(CommonInputPassword)`
-  font-size: ${(props) => props.theme.commonFontSizes.md};
   color: ${(props) => props.theme.colors.text.main};
-  font-weight: ${(props) => props.theme.commonFontWeight.semibold};
   background: transparent;
 
   & input.ant-input {


### PR DESCRIPTION
# Description

Removed unnecessary font-weight and font-size from inputs on auth pages

Fixes #180 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
