### PR TITLE
refactor(button & kanban): nostyle prop for btn & hover for kanban

### DIFF
--- a/src/components/apps/kanban/Card/Card.styles.ts
+++ b/src/components/apps/kanban/Card/Card.styles.ts
@@ -43,26 +43,8 @@ export const ParticipantsWrapper = styled.div`
   gap: 1rem;
 `;
 
-export const ArrowDownWrapper = styled.span`
-  padding-right: 1.25rem;
-  width: 1.5rem;
-
-  color: ${(props) => props.theme.colors.text.main};
-`;
-
 export const ArrowDownIcon = styled(DownOutlined)<ArrowDownIcon>`
   transform: ${(props) => `rotate(${props.$expanded ? 0 : 180}deg)`};
-`;
-
-export const ThreeDotsWrapper = styled.span`
-  width: 1.5rem;
-  font-size: ${(props) => props.theme.commonFontSizes.xl};
-  height: 1.375rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  color: ${(props) => props.theme.colors.text.main};
 `;
 
 export const CardWrapper = styled(MovableCardWrapper)`
@@ -72,8 +54,9 @@ export const CardWrapper = styled(MovableCardWrapper)`
 export const CardRightContent = styled(RightContent)`
   display: flex;
   justify-content: flex-end;
-  padding-right: 0;
   align-items: center;
+  gap: 1rem;
+  padding-right: 0;
 `;
 
 export const CardTitle = styled(Title)`

--- a/src/components/apps/kanban/Card/Card.styles.ts
+++ b/src/components/apps/kanban/Card/Card.styles.ts
@@ -8,7 +8,7 @@ import {
   Footer,
 } from 'react-trello/dist/styles/Base';
 import { DownOutlined } from '@ant-design/icons';
-import { Collapse } from 'antd';
+import { Collapse, Menu } from 'antd';
 import InlineInput from 'react-trello/dist/widgets/InlineInput';
 
 const { Panel } = Collapse;
@@ -94,26 +94,12 @@ export const CardFooter = styled(Footer)`
   justify-content: flex-start;
 `;
 
-export const EditPopover = styled.div`
-  display: flex;
-  background: ${(props) => props.theme.colors.main.mainBackground};
-  flex-direction: column;
-  border-radius: 0.625rem;
-  padding: 1rem;
-  z-index: 1;
-  filter: drop-shadow(0 0 3px rgba(0, 0, 0, 0.2));
+export const CardMenu = styled(Menu)`
+  box-shadow: ${(props) => props.theme.boxShadow.hover};
 `;
 
-export const EditPopoverLine = styled.span`
+export const MenuItem = styled(Menu.Item)`
   font-size: ${(props) => props.theme.commonFontSizes.xs};
-  line-height: 1.25rem;
-  padding-bottom: 0.625rem;
-  display: flex;
-  &:last-child {
-    padding-bottom: 0;
-  }
-  color: ${(props) => props.theme.colors.text.main};
-  cursor: pointer;
 `;
 
 export const Input = styled(InlineInput)`

--- a/src/components/apps/kanban/Card/Card.tsx
+++ b/src/components/apps/kanban/Card/Card.tsx
@@ -24,18 +24,23 @@ interface CardProps {
 }
 
 interface EditPopoverProps {
-  onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onArchive: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onDelete: () => void;
+  onArchive: () => void;
 }
 
-const EditPopover: React.FC<EditPopoverProps> = ({ onDelete, onArchive }) => {
+const EditPopover: React.FC<EditPopoverProps> = ({ onDelete, onArchive, ...props }) => {
   const { t } = useTranslation();
 
   return (
-    <S.EditPopover>
-      <S.EditPopoverLine onClick={onDelete}>{t('common.delete')}</S.EditPopoverLine>
-      <S.EditPopoverLine onClick={onArchive}>{t('kanban.archive')}</S.EditPopoverLine>
-    </S.EditPopover>
+    <S.CardMenu selectable={false} {...props}>
+      <S.MenuItem key="1" onClick={onDelete}>
+        {t('common.delete')}
+      </S.MenuItem>
+
+      <S.MenuItem key="2" onClick={onArchive}>
+        {t('kanban.archive')}
+      </S.MenuItem>
+    </S.CardMenu>
   );
 };
 
@@ -64,9 +69,8 @@ export const Card: React.FC<CardProps> = ({
     onChange({ ...card, id });
   };
 
-  const onDeleteCard = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const onDeleteCard = () => {
     onDelete();
-    event.stopPropagation();
   };
 
   const updateTags = (tags: ITag[]) => {

--- a/src/components/apps/kanban/Card/Card.tsx
+++ b/src/components/apps/kanban/Card/Card.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { CardState, Tag as ITag, Participant as IParticipant } from '../interfaces';
-import { MoreOutlined } from '@ant-design/icons';
-import * as S from './Card.styles';
 import { Dropdown } from 'antd';
-import { ParticipantsDropdown } from '../newCardForm/ParticipantsDropdown/ParticipantsDropdown';
-import { TagDropdown } from '../newCardForm/TagDropdown/TagDropdown';
 import { useTranslation } from 'react-i18next';
+import { MoreOutlined } from '@ant-design/icons';
+import { Button } from '@app/components/common/buttons/Button/Button';
+import { ParticipantsDropdown } from '@app/components/apps/kanban/newCardForm/ParticipantsDropdown/ParticipantsDropdown';
+import { TagDropdown } from '@app/components/apps/kanban/newCardForm/TagDropdown/TagDropdown';
+import { CardState, Tag as ITag, Participant as IParticipant } from '@app/components/apps/kanban/interfaces';
+import * as S from './Card.styles';
 
 interface CardProps {
   style: CSSStyleSheet;
@@ -104,21 +105,20 @@ export const Card: React.FC<CardProps> = ({
                 )}
               </S.CardTitle>
               <S.CardRightContent>
-                <S.ArrowDownWrapper>
-                  <S.ArrowDownIcon $expanded={isExpanded} />
-                </S.ArrowDownWrapper>
+                <Button noStyle type="text" icon={<S.ArrowDownIcon $expanded={isExpanded} />} />
                 <Dropdown
                   overlay={<EditPopover onDelete={onDeleteCard} onArchive={onDeleteCard} />}
                   placement="bottomRight"
                   trigger={['click']}
                 >
-                  <S.ThreeDotsWrapper
+                  <Button
+                    noStyle
+                    type="text"
+                    icon={<MoreOutlined />}
                     onClick={(e) => {
                       e.stopPropagation();
                     }}
-                  >
-                    <MoreOutlined />
-                  </S.ThreeDotsWrapper>
+                  />
                 </Dropdown>
               </S.CardRightContent>
             </S.CardHeader>

--- a/src/components/common/buttons/Button/Button.styles.ts
+++ b/src/components/common/buttons/Button/Button.styles.ts
@@ -7,9 +7,18 @@ import { defineColorBySeverity, hexToRGB, shadeColor } from '@app/utils/utils';
 interface BtnProps {
   type: ButtonType;
   $severity?: Severity;
+  $noStyle?: boolean;
 }
 
 export const Button = styled(AntButton)<BtnProps>`
+  ${(props) =>
+    props.$noStyle &&
+    css`
+      width: unset;
+      padding: 0;
+      height: unset;
+    `}
+
   ${(props) =>
     !props.danger &&
     css`

--- a/src/components/common/buttons/Button/Button.tsx
+++ b/src/components/common/buttons/Button/Button.tsx
@@ -9,12 +9,20 @@ export const { Group: ButtonGroup } = AntdButton;
 export interface ButtonProps extends AntButtonProps {
   className?: string;
   type?: ButtonType;
-  $severity?: Severity;
+  severity?: Severity;
+  noStyle?: boolean;
 }
 
 export const Button = React.forwardRef<HTMLElement, ButtonProps>(
-  ({ className, type = 'ghost', $severity, children, ...props }, ref) => (
-    <S.Button ref={ref} type={$severity ? 'primary' : type} className={className} {...props} $severity={$severity}>
+  ({ className, type = 'ghost', severity, noStyle, children, ...props }, ref) => (
+    <S.Button
+      ref={ref}
+      type={severity ? 'primary' : type}
+      className={className}
+      $noStyle={noStyle}
+      {...props}
+      $severity={severity}
+    >
       {children}
     </S.Button>
   ),

--- a/src/components/header/Header/Header.styles.ts
+++ b/src/components/header/Header/Header.styles.ts
@@ -4,7 +4,6 @@ import { BurgerIcon } from '@app/components/common/Burger/BurgerIcon';
 import { GitHubButton } from '@app/components/header/GitHubButton';
 
 export const DropdownMenu = styled(Menu)`
-  background-color: ${(props) => props.theme.colors.main.mainBackground};
   box-shadow: ${(props) => props.theme.boxShadow.main};
   border-radius: ${(props) => props.theme.border.radius};
   line-height: 1.5715;

--- a/src/pages/uiComponentsPages/ButtonsPage.tsx
+++ b/src/pages/uiComponentsPages/ButtonsPage.tsx
@@ -43,10 +43,10 @@ const ButtonsPage: React.FC = () => {
         <Button type="link">{t('buttons.link')}</Button>
       </S.Card>
       <S.Card title={t('buttons.severities')}>
-        <Button $severity="info">{t('common.info')}</Button>
-        <Button $severity="success">{t('common.success')}</Button>
-        <Button $severity="warning">{t('common.warning')}</Button>
-        <Button $severity="error">{t('common.error')}</Button>
+        <Button severity="info">{t('common.info')}</Button>
+        <Button severity="success">{t('common.success')}</Button>
+        <Button severity="warning">{t('common.warning')}</Button>
+        <Button severity="error">{t('common.error')}</Button>
       </S.Card>
       <S.Card title={t('buttons.sizes')}>
         <Button type="ghost" size="small">

--- a/src/pages/uiComponentsPages/feedback/NotificationsPage.tsx
+++ b/src/pages/uiComponentsPages/feedback/NotificationsPage.tsx
@@ -11,7 +11,7 @@ const NotificationsPage: React.FC = () => {
     <Col>
       <S.Card title={t('notifications.basic')}>
         <Button
-          $severity="info"
+          severity="info"
           onClick={() =>
             notificationController.info({
               message: t('notifications.infoTitle'),
@@ -24,7 +24,7 @@ const NotificationsPage: React.FC = () => {
       </S.Card>
       <S.Card title={t('notifications.types')}>
         <Button
-          $severity="success"
+          severity="success"
           onClick={() =>
             notificationController.success({
               message: t('notifications.successTitle'),
@@ -35,7 +35,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.success')}
         </Button>
         <Button
-          $severity="info"
+          severity="info"
           onClick={() =>
             notificationController.info({
               message: t('notifications.infoTitle'),
@@ -46,7 +46,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.info')}
         </Button>
         <Button
-          $severity="warning"
+          severity="warning"
           onClick={() =>
             notificationController.warning({
               message: t('notifications.warningTitle'),
@@ -57,7 +57,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.warning')}
         </Button>
         <Button
-          $severity="error"
+          severity="error"
           onClick={() =>
             notificationController.error({
               message: t('notifications.errorTitle'),
@@ -70,7 +70,7 @@ const NotificationsPage: React.FC = () => {
       </S.Card>
       <S.Card title={t('notifications.withoutDescription')}>
         <Button
-          $severity="success"
+          severity="success"
           onClick={() =>
             notificationController.success({
               message: t('notifications.successTitle'),
@@ -80,7 +80,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.success')}
         </Button>
         <Button
-          $severity="info"
+          severity="info"
           onClick={() =>
             notificationController.info({
               message: t('notifications.infoTitle'),
@@ -90,7 +90,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.info')}
         </Button>
         <Button
-          $severity="warning"
+          severity="warning"
           onClick={() =>
             notificationController.warning({
               message: t('notifications.warningTitle'),
@@ -100,7 +100,7 @@ const NotificationsPage: React.FC = () => {
           {t('notifications.warning')}
         </Button>
         <Button
-          $severity="error"
+          severity="error"
           onClick={() =>
             notificationController.error({
               message: t('notifications.errorTitle'),

--- a/src/pages/uiComponentsPages/modals/ModalsPage.tsx
+++ b/src/pages/uiComponentsPages/modals/ModalsPage.tsx
@@ -121,16 +121,16 @@ const ModalsPage: React.FC = () => {
         </Modal>
       </S.Card>
       <S.Card title={t('modals.infoModal')}>
-        <Button $severity="success" type="default" onClick={success}>
+        <Button severity="success" type="default" onClick={success}>
           {t('modals.success')}
         </Button>
-        <Button $severity="info" type="default" onClick={info}>
+        <Button severity="info" type="default" onClick={info}>
           {t('modals.info')}
         </Button>
-        <Button $severity="warning" type="default" onClick={warning}>
+        <Button severity="warning" type="default" onClick={warning}>
           {t('modals.warning')}
         </Button>
-        <Button $severity="error" type="default" onClick={error}>
+        <Button severity="error" type="default" onClick={error}>
           {t('modals.error')}
         </Button>
       </S.Card>


### PR DESCRIPTION

# Description

1) Button: added new prop `noStyle` -  removed width, height, padding of button
2) "More options" and "expand" are buttons now (kanban)

Fixes #194 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

tested locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
