### PR TITLE
 modify --openssl-legacy-provider in pacakge

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
     "workbox-streams": "^5.1.3"
   },
   "scripts": {
-    "start": "yarn buildThemes && craco start",
-    "build": "yarn buildThemes && craco build",
+    "start": "yarn buildThemes && craco --openssl-legacy-provider start",
+    "build": "yarn buildThemes && craco --openssl-legacy-provider build",
     "test": "craco test",
     "eject": "craco eject",
     "lint": "eslint \"*/**/*.{js,ts,tsx}\" --fix",


### PR DESCRIPTION
# Description

This pull request addresses the issue related to the OpenSSL error stack, specifically:

```
{
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}
```

The problem has been resolved by adding the `--openssl-legacy-provider` flag in the start script as follows:

```json
"start": "yarn buildThemes && craco --openssl-legacy-provider start"
```

This change fixes the issue # (replace with the relevant issue number).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have tested this change locally by running the updated start script with the `--openssl-legacy-provider` flag. The application started without encountering the OpenSSL error mentioned above.

To test this change:
1. Clone this repository.
2. Install dependencies with `yarn install`.
3. Run the start script with the `yarn start`.

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Modified project build and start scripts to include compatibility flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->